### PR TITLE
Make core work if the frontend doesn't implement the frame time callback.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -195,6 +195,7 @@ bool retro_load_game(const struct retro_game_info *info)
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "Down" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Pause" },
       { 0 },
    };
 


### PR DESCRIPTION
It'll work better if the front knows what the frame time is, of course, but it's completely unplayable without that right now.
I could make it throw an error if the env returns false, but that's actually more effort than needed to get it to work without that env.
