### PR TITLE
Remove both warnings from 2048

### DIFF
--- a/game.h
+++ b/game.h
@@ -6,7 +6,7 @@
 
 #define FONT "cairo:monospace"
 #define FONT_SIZE 20
-#define SPACING    (FONT_SIZE * 0.4)
+#define SPACING    (int)(FONT_SIZE * 0.4)
 #define TILE_SIZE (FONT_SIZE * 4)
 #define TILE_ANIM_SPEED 5
 

--- a/game_noncairo.c
+++ b/game_noncairo.c
@@ -173,13 +173,6 @@ static void fill_rectangle(int ctx, int x, int y, int w, int h)
    DrawFBoxBmp(ptr, x, y, w, h, nullctx.color);
 }
 
-static void draw_text(int ctx, const char *utf8, int x, int y)
-{
-   char *ptr=(char*)frame_buf;
-   int size=strlen(utf8);
-   Draw_text(ptr,x,y,nullctx.color,0 ,nullctx.fontsize_x,nullctx.fontsize_y ,size, utf8);
-}
-
 static void draw_text_centered(int ctx, const char *utf8, int x, int y, int w, int h)
 {
 


### PR DESCRIPTION
I get two warnings from 2048.  I like 2048.  It's a very simple, fun puzzle.  And the version in libretro is damned nearly a hello world for the libretro API, or it would be if we allowed it to become a deep fork and removed the dependency cruft.  :)

But it generates two big warnings for me that clang explains in its usual exhaustive and surprisingly mostly helpful way.  They're trivial; I've fixed them.