### PR TITLE
Report git version as library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -29,8 +29,10 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 endif
 
 TARGET_NAME := 2048
-GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags)"
-CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags || echo unknown)"
+ifneq ($(GIT_VERSION),"unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 LIBM := -lm
 fpic=
 

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -29,6 +29,8 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 endif
 
 TARGET_NAME := 2048
+GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags)"
+CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 LIBM := -lm
 fpic=
 

--- a/libretro.c
+++ b/libretro.c
@@ -127,7 +127,11 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "2048";
+#ifdef GIT_VERSION
+   info->library_version  = GIT_VERSION;
+#else
    info->library_version  = "v1.0";
+#endif
    info->need_fullpath    = false;
    info->valid_extensions = NULL; /* Anything is fine, we don't care. */
 }


### PR DESCRIPTION
This patch makes this core report the git version as its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.