### PR TITLE
Allow setting GIT_VERSION

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -29,7 +29,7 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 endif
 
 TARGET_NAME := 2048
-GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif


### PR DESCRIPTION
When making slackbuilds for libretro cores I have to package the source code myself as cloning with git during the build process is not accepted as slackbuilds.org. During this process I remove the `.git` directory from the source directory as its not needed and can be very large for some cores (mame). However many libretro cores set `GIT_VERSION` which adds a useful git hash in the RetroArch menu next to the version, but without the git directory the following error will be printed.
```
fatal: Not a git repository (or any parent up to mount point /tmp)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```
This can be easily avoided by using ?= instead of := in the makefile and then adding the following to my slackbuilds which have the git hash already provided in the version.
```
VERSION=2017.01.18_04df835

make GIT_VERSION=$(echo $VERSION | cut -d '_' -f 2)
```
Of course if GIT_VERSION is not set then the default behavior will still be used. If this is acceptable for libretro I will submit more PRs for other cores with time.