### PR TITLE
Use RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY to work around problems wi…

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -40,7 +40,7 @@ void retro_init(void)
 
    game_init();
 
-   environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &savedir);
+   environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &savedir);
 
    if (savedir)
    {
@@ -76,7 +76,7 @@ void retro_init(void)
 void retro_deinit(void)
 {
    char *savedir = NULL;
-   environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &savedir);
+   environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &savedir);
 
    if (savedir)
    {


### PR DESCRIPTION
…th the savedir.

Since 2048 doesn't have any content it has problems with the RetroArch save directory. This is especially apparent when cores are installed to read only directories through a distro's package management. 2048 will either then try to save to a read only directory which won't work or the save will end up in the wrong place if used with `Sort Saves In Folders`. For example I found in my 2048.srm in the GLupeN64 save directory.

So I looked at Craft which also does not have any content and found it uses `RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY` instead. So while this may not be an ideal solution, it works much better for now and will be trivial to change back if and when the save directory behavior is improved.

Please also see issue https://github.com/libretro/libretro-2048/issues/4.