### PR TITLE
AppleTVOS platform build fix

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -120,6 +120,7 @@ else ifeq ($(platform), tvos-arm64)
 ifeq ($(IOSSDK),)
    IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
 endif
+   CC = cc -arch arm64 -isysroot $(IOSSDK)
 else ifeq ($(platform), theos_ios)
 	# Theos iOS
 DEPLOYMENT_IOSVERSION = 5.0


### PR DESCRIPTION
Fixes building for Apple TVOS platform.

prior to this, we get incorrect sysroot and arch target. Snippet of the build Log is below

```
/Applications/Xcode10.2.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.2.sdk -miphoneos-version-min=5.0 -fPIC -dynamiclib -miphoneos-version-min=5.0   -o 2048_libretro_ios.dylib ./libretro.o ./game_noncairo.o ./game_shared.o  -lm
15:11:47 clang: warning: using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:47 ld: warning: ignoring file /Applications/Xcode10.2.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.2.sdk/usr/lib/libm.tbd, missing required architecture armv7 in file /Applications/Xcode10.2.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.2.sdk/usr/lib/libm.tbdld: warning: ignoring file /Applications/Xcode10.2.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.2.sdk/usr/lib/libSystem.tbd, missing required architecture armv7 in file /Applications/Xcode10.2.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.2.sdk/usr/lib/libSystem.tbd
15:11:47 
15:11:47 Undefined symbols for architecture armv7:
15:11:47   "___error", referenced from:
```

Tested with Kodi libretro implementation on AppleTVOS 13.1 using Xcode 11