### PR TITLE
Change -mmacosx-version-min=10.1 to -mmacosx-version-min=10.4

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -82,7 +82,7 @@ else ifeq ($(platform), osx)
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
    OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
    ifeq ($(OSX_LT_MAVERICKS),YES)
-   	   fpic += -mmacosx-version-min=10.1
+   	   fpic += -mmacosx-version-min=10.4
    endif
 
    ifeq ($(CROSS_COMPILE),1)


### PR DESCRIPTION
-mmacosx-version-min=10.1 has no effect on our build system and
it default to 10.6. We need either to use 10.4 explicitly or remove it
altogether relying on ci-templates. Keep it in case somebody compiles
themselves on 10.6 (why would you is beyond me though)