### PR TITLE
Use a float for new tile spawn; fixes #60

### DIFF
--- a/game_shared.c
+++ b/game_shared.c
@@ -113,7 +113,7 @@ static void add_tile(void)
       empty[j]->source = NULL;
       empty[j]->move_time = 1;
       empty[j]->appear_time = 0;
-      empty[j]->value = (rand() / RAND_MAX) < 0.9 ? 1 : 2;
+      empty[j]->value = ((float)rand() / RAND_MAX) < 0.9 ? 1 : 2;
    }
    else
       change_state(STATE_GAME_OVER);


### PR DESCRIPTION
Random 2/4 tile generation is broken currently because it's based on calculating whether a random **integer** between 0 and 1 is greater than 0.9. In practice this just means every possible decimal value will be truncated to 0, resulting in a 2 tile being generated in every instance except for the impossibly rare case of exactly 1.0 being the random value arrived at.

Using a float makes this behave as was actually intended, with a 90% chance of generating a 2 and 10% chance of a 4.

Fixes #60