### PR TITLE
Fix highscore not saved on win

### DIFF
--- a/game_shared.c
+++ b/game_shared.c
@@ -295,7 +295,7 @@ static bool move_tiles(void)
             moved = true;
 
             if (next->value == 11)
-               game.state = STATE_WON;
+               change_state(STATE_WON);
          }
          else if (farthest != cell)
          {


### PR DESCRIPTION
When a tile merged to 2048, move_tiles() set game.state = STATE_WON directly, bypassing change_state() and the end_game() call inside it. This meant best_score was never updated on a win. Game over worked correctly because it always went through change_state().