### PR TITLE
Only save best score when ending, not when continuing past 2048

### DIFF
--- a/game_shared.c
+++ b/game_shared.c
@@ -386,11 +386,14 @@ void change_state(game_state_t state)
          break;
       case STATE_PLAYING:
          assert(state == STATE_GAME_OVER || state == STATE_WON || state == STATE_PAUSED);
-         if (state != STATE_PAUSED)
+         /* Only save best score on actual game over, not when reaching 2048 */
+         if (state == STATE_GAME_OVER)
             end_game();
          break;
       case STATE_WON:
-         end_game();
+         /* Only save best score when returning to menu, not when continuing */
+         if (state == STATE_TITLE)
+            end_game();
          assert(state == STATE_TITLE || state == STATE_PLAYING);
          break;
       case STATE_PAUSED:


### PR DESCRIPTION
Previously the best score was updated both when reaching 2048 and when choosing to keep going. Now it only saves on game over or returning to the menu so the old best score is still visible while continuing.