### PR TITLE
Alternate inputs each frame when holding two directions simultaneously

### DIFF
--- a/game.h
+++ b/game.h
@@ -76,6 +76,8 @@ typedef struct game {
    key_state_t old_ks;
    direction_t direction;
    cell_t grid[GRID_SIZE];
+
+   bool auto_diagonals; /* alternate inputs when two directions held simultaneously */
 } game_t;
 
 extern retro_environment_t environ_cb;

--- a/game_noncairo.c
+++ b/game_noncairo.c
@@ -479,17 +479,30 @@ void render_title(void)
    draw_text_centered(ctx, "2048", 0, 0, SCREEN_WIDTH, TILE_SIZE*3);
 
 
-   if (dark_theme)
-      set_rgb(ctx, 70, 83, 96);
-   else
-      set_rgb(ctx, 185, 172, 159);
-   fill_rectangle(ctx, TILE_SIZE / 2, TILE_SIZE * 4, SCREEN_HEIGHT - TILE_SIZE * 2, FONT_SIZE * 3);
+   {
+      int bw = SCREEN_HEIGHT - TILE_SIZE * 2;
+      int bh = FONT_SIZE * 3;
+      int bx = TILE_SIZE / 2;
+      int by = TILE_SIZE * 4;
+      char diag_label[32];
 
-   nullctx_fontsize(1);
-   nullctx.color = dark_theme ? color_lut_dark[1] : color_lut[1];
+      if (dark_theme) set_rgb(ctx, 70, 83, 96);
+      else            set_rgb(ctx, 185, 172, 159);
+      fill_rectangle(ctx, bx, by, bw, bh);
+      fill_rectangle(ctx, bx, by + bh + SPACING, bw, bh);
 
-   draw_text_centered(ctx, "PRESS START", TILE_SIZE / 2 + SPACING, TILE_SIZE * 4 + SPACING,
-                      SCREEN_HEIGHT - TILE_SIZE * 2 - SPACING * 2, FONT_SIZE * 3 - SPACING * 2);
+      sprintf(diag_label, "< AUTO DIAGONALS: %s >",
+              game_get_auto_diagonals() ? "ON" : "OFF");
+
+      nullctx_fontsize(1);
+      nullctx.color = dark_theme ? color_lut_dark[1] : color_lut[1];
+      draw_text_centered(ctx, "PRESS START",
+                         bx + SPACING, by + SPACING,
+                         bw - SPACING * 2, bh - SPACING * 2);
+      draw_text_centered(ctx, diag_label,
+                         bx + SPACING, by + bh + SPACING * 2,
+                         bw - SPACING * 2, bh - SPACING * 2);
+   }
 
 }
 

--- a/game_shared.c
+++ b/game_shared.c
@@ -12,6 +12,9 @@ static int delta_score;
 static float delta_score_time;
 static float frame_time = 0.016;
 
+/* Last direction used during multi-button alternation */
+static direction_t last_alt_dir = DIR_NONE;
+
 #define PI 3.14159
 
 /* out back bicubic
@@ -152,6 +155,7 @@ void start_game(void)
    /* reset +score animation */
    delta_score      = 0;
    delta_score_time = 1;
+   last_alt_dir     = DIR_NONE;
 
    add_tile();
    add_tile();
@@ -416,15 +420,49 @@ void handle_input(key_state_t *ks)
    }
    else if (game.state == STATE_PLAYING)
    {
-      if (ks->up && !game.old_ks.up)
-         game.direction = DIR_UP;
-      else if (ks->right && !game.old_ks.right)
-         game.direction = DIR_RIGHT;
-      else if (ks->down && !game.old_ks.down)
-         game.direction = DIR_DOWN;
-      else if (ks->left && !game.old_ks.left)
-         game.direction = DIR_LEFT;
-      else if (ks->start && !game.old_ks.start)
+      direction_t held_dirs[4];
+      int held_count = 0;
+      int i;
+
+      if (ks->up)    held_dirs[held_count++] = DIR_UP;
+      if (ks->right) held_dirs[held_count++] = DIR_RIGHT;
+      if (ks->down)  held_dirs[held_count++] = DIR_DOWN;
+      if (ks->left)  held_dirs[held_count++] = DIR_LEFT;
+
+      if (held_count == 1)
+      {
+         /* Single direction: trigger on new press only */
+         if (ks->up && !game.old_ks.up)
+            game.direction = DIR_UP;
+         else if (ks->right && !game.old_ks.right)
+            game.direction = DIR_RIGHT;
+         else if (ks->down && !game.old_ks.down)
+            game.direction = DIR_DOWN;
+         else if (ks->left && !game.old_ks.left)
+            game.direction = DIR_LEFT;
+         last_alt_dir = held_dirs[0];
+      }
+      else if (held_count >= 2)
+      {
+         /* Multiple directions held: alternate between them each frame */
+         int next_idx = 0;
+         for (i = 0; i < held_count; i++)
+         {
+            if (held_dirs[i] == last_alt_dir)
+            {
+               next_idx = (i + 1) % held_count;
+               break;
+            }
+         }
+         game.direction = held_dirs[next_idx];
+         last_alt_dir = held_dirs[next_idx];
+      }
+      else
+      {
+         last_alt_dir = DIR_NONE;
+      }
+
+      if (ks->start && !game.old_ks.start)
          change_state(STATE_PAUSED);
    }
    else if (game.state == STATE_PAUSED)

--- a/game_shared.c
+++ b/game_shared.c
@@ -363,6 +363,12 @@ int game_get_best_score(void)
 {
    return game.best_score;
 }
+
+bool game_get_auto_diagonals(void)
+{
+   return game.auto_diagonals;
+}
+
 cell_t * game_get_grid(void)
 {
    return game.grid;
@@ -417,6 +423,9 @@ void handle_input(key_state_t *ks)
          change_state(STATE_PLAYING);
          add_tile();
       }
+      else if (game.state == STATE_TITLE &&
+               ((ks->left && !game.old_ks.left) || (ks->right && !game.old_ks.right)))
+         game.auto_diagonals = !game.auto_diagonals;
    }
    else if (game.state == STATE_PLAYING)
    {
@@ -442,7 +451,7 @@ void handle_input(key_state_t *ks)
             game.direction = DIR_LEFT;
          last_alt_dir = held_dirs[0];
       }
-      else if (held_count >= 2)
+      else if (held_count >= 2 && game.auto_diagonals)
       {
          /* Multiple directions held: alternate between them each frame */
          int next_idx = 0;

--- a/game_shared.h
+++ b/game_shared.h
@@ -19,6 +19,7 @@ void handle_input(key_state_t *ks);
 int game_get_score(void);
 int game_get_best_score(void);
 cell_t * game_get_grid(void);
+bool game_get_auto_diagonals(void);
 int *game_get_delta_score(void);
 float *game_get_delta_score_time(void);
 float *game_get_frame_time(void);


### PR DESCRIPTION
Single button press still triggers once on initial press. When two or more direction buttons are held at once, the game cycles through them every frame for maximum move rate.

---

When the board is sorted diagonally, it is pretty safe to just spam the two directions to the biggest corner. That's significantly easier on a keyboard than on a dpad. So I added this feature.

Feel free to close if this is not a desired change.